### PR TITLE
Release v1.0.1 — metadata + docs patch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Research-backed fitness skills for body composition, rep max estimation, and macronutrient planning",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "fitness-tools",
       "source": "./",
       "description": "3 specialized fitness skills providing body composition assessment (Durnin-Womersley, Jackson-Pollock 3/4/7-site), one-rep max estimation (validated percentage table), and macronutrient meal planning (ectomorph, mesomorph, endomorph body types). Powered by the fitness-tools Python library.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "jeffallan",
         "email": "github@jeffallan"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "jeffallan"
   },
   "metadata": {
-    "description": "ACSM-sourced fitness skills for body composition, rep max estimation, and macronutrient planning",
+    "description": "Research-backed fitness skills for body composition, rep max estimation, and macronutrient planning",
     "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "fitness-tools",
       "source": "./",
-      "description": "3 specialized fitness skills providing body composition assessment (Durnin-Womersley, Jackson-Pollock 3/4/7-site), one-rep max estimation (ACSM percentage table), and macronutrient meal planning (ectomorph, mesomorph, endomorph body types). Powered by the fitness-tools Python library.",
+      "description": "3 specialized fitness skills providing body composition assessment (Durnin-Womersley, Jackson-Pollock 3/4/7-site), one-rep max estimation (validated percentage table), and macronutrient meal planning (ectomorph, mesomorph, endomorph body types). Powered by the fitness-tools Python library.",
       "version": "1.0.0",
       "author": {
         "name": "jeffallan",
@@ -30,7 +30,6 @@
         "1rm",
         "macros",
         "meal-planning",
-        "acsm",
         "jackson-pollock",
         "durnin-womersley",
         "model-invoked"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fitness-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "3 specialized fitness skills providing body composition assessment (Durnin-Womersley, Jackson-Pollock 3/4/7-site), one-rep max estimation (validated percentage table), and macronutrient meal planning (ectomorph, mesomorph, endomorph body types). Powered by the fitness-tools Python library.",
   "author": {
     "name": "jeffallan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fitness-tools",
   "version": "1.0.0",
-  "description": "3 specialized fitness skills providing body composition assessment (Durnin-Womersley, Jackson-Pollock 3/4/7-site), one-rep max estimation (ACSM percentage table), and macronutrient meal planning (ectomorph, mesomorph, endomorph body types). Powered by the fitness-tools Python library.",
+  "description": "3 specialized fitness skills providing body composition assessment (Durnin-Womersley, Jackson-Pollock 3/4/7-site), one-rep max estimation (validated percentage table), and macronutrient meal planning (ectomorph, mesomorph, endomorph body types). Powered by the fitness-tools Python library.",
   "author": {
     "name": "jeffallan",
     "email": "github@jeffallan"
@@ -18,7 +18,6 @@
     "1rm",
     "macros",
     "meal-planning",
-    "acsm",
     "jackson-pollock",
     "durnin-womersley",
     "model-invoked"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2026-04-15
+
+### Fixed
+
+- **README example** — `DurninWomersley` quick-start used `skinfolds=` keyword argument, which raised `TypeError` against the `*args` signature. Switched to positional form.
+- **`ActivityLevel` documentation** — `docs-library/meal-planning.md` listed `"light"` and `"extra"` as accepted values; only `"sedentary"`, `"moderate"`, and `"very"` exist on the enum. Corrected the accepted-values table.
+
+### Changed
+
+- **Author metadata** updated to `jeffallan` (https://jeffallan.github.io); removes stale attribution from the original v0.1.x package author.
+- **Package description** and marketing copy reframed from "ACSM-sourced equations" to "validated, research-backed equations" across README, PyPI description, marketplace metadata, and the docs site landing page. Deep scholarly references (equation-source citations in reference docs) kept intact.
+- **README header** — new capsule-render banner (sky blue → amber gradient), stats line, and shields.io badge row (PyPI version, Python versions, license, Claude Code Plugin, stars, CI). Matches style of sibling repos.
+- **Docs-site landing page** — real install commands (`/plugin marketplace add` + `npx skills add`) replace the stub `claude install` command.
+- Terminology unified on **"Agent Skills"** (capitalized) across README and docs site.
+
+### Infrastructure
+
+- **Release workflow** — `actions/configure-pages@v5` now passes `enablement: true` so GitHub Pages auto-initializes on first run; future releases don't require manual Pages-enable gymnastics.
+- **CI** now triggers on PRs to `develop` (previously master-only) and declares `workflow_call` so `release.yml` can reuse it.
+- **Package build config** — explicit `[tool.setuptools.packages.find]` ensures only `fitness_tools/` ships; prevents `site/`, `skills/`, and `docs-library/` from confusing setuptools flat-layout auto-discovery.
+
 ## [1.0.0] - 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
-# Fitness Tools
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20%26%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools" />
+</p>
 
-**Healthy Lifestyles With Python**
+<p align="center">
+  Python Package · <!-- SKILL_COUNT -->3<!-- /SKILL_COUNT --> Agent Skills
+</p>
 
-Fitness Tools is a Python package that facilitates healthy lifestyles using ACSM-sourced equations. Whether you're a wellness professional, veteran gym rat, or just starting your fitness journey, this package will benefit you.
+<p align="center">
+  <a href="https://pypi.org/project/fitness-tools/"><img src="https://img.shields.io/pypi/v/fitness-tools?style=for-the-badge&color=blue" alt="PyPI version" /></a>
+  <a href="https://pypi.org/project/fitness-tools/"><img src="https://img.shields.io/pypi/pyversions/fitness-tools?style=for-the-badge" alt="Python versions" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg?style=for-the-badge" alt="License" /></a>
+  <a href="https://github.com/Jeffallan/Fitness-Tools"><img src="https://img.shields.io/badge/Claude_Code-Plugin-purple.svg?style=for-the-badge" alt="Claude Code Plugin" /></a>
+  <a href="https://github.com/Jeffallan/Fitness-Tools/stargazers"><img src="https://img.shields.io/github/stars/Jeffallan/Fitness-Tools?style=for-the-badge&color=yellow" alt="GitHub Stars" /></a>
+  <a href="https://github.com/Jeffallan/Fitness-Tools/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Jeffallan/Fitness-Tools/ci.yml?branch=master&style=for-the-badge&label=CI" alt="CI" /></a>
+</p>
+
+---
+
+Fitness Tools is a Python package that facilitates healthy lifestyles using validated, research-backed equations. Whether you're a wellness professional, veteran gym rat, or just starting your fitness journey, this package will benefit you.
 
 ## Features
 
 - **Body Composition** — Estimate body fat percentage from skinfold measurements using Durnin-Womersley and Jackson-Pollock (3/4/7-site) equations
-- **Rep Max Estimation** — Convert between weight and rep ranges using the ACSM percentage-of-1RM table
+- **Rep Max Estimation** — Convert between weight and rep ranges using a validated percentage-of-1RM table
 - **Macronutrient Planning** — Calculate daily calorie ranges and macro distributions by body type, activity level, and goal
 
 ## Quick Start
@@ -71,7 +86,7 @@ This package includes 3 skills for AI-assisted fitness calculations:
 | Skill | Description |
 |-------|-------------|
 | `body-composition` | Skinfold-based body fat assessment |
-| `rep-max` | One-rep max estimation via ACSM table |
+| `rep-max` | One-rep max estimation via validated percentage table |
 | `meal-planner` | Macronutrient planning by body type |
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20%26%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20%26%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools banner — Python Package and Agent Skills" />
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ pip install fitness-tools
 ```python
 from fitness_tools import DurninWomersley, Sex
 
-calc = DurninWomersley(age=30, sex=Sex.MALE, skinfolds=(12, 8, 15, 10))
+calc = DurninWomersley(30, Sex.MALE, (12, 8, 15, 10))
 density = calc.body_density()
 body_fat = calc.siri(density)
 ```

--- a/docs-library/meal-planning.md
+++ b/docs-library/meal-planning.md
@@ -105,7 +105,7 @@ You control everything. Set macro percentages and calorie ranges manually.
 | Parameter | Accepted values |
 |---|---|
 | `body_type` | `"ectomorph"`, `"mesomorph"`, `"endomorph"` (or `BodyType.*`) |
-| `activity_level` | `"sedentary"`, `"light"`, `"moderate"`, `"very"`, `"extra"` (or `ActivityLevel.*`) |
+| `activity_level` | `"sedentary"`, `"moderate"`, `"very"` (or `ActivityLevel.*`) |
 | `goal` | `"weight_loss"`, `"maintenance"`, `"weight_gain"` (or `Goal.*`) |
 | `fat_percent`, `protein_percent`, `carb_percent` | Floats that must sum to `1.0` |
 | `min_cal`, `max_cal` | Calories per pound of body weight |

--- a/docs-library/rep-max.md
+++ b/docs-library/rep-max.md
@@ -7,7 +7,7 @@ Different repetition ranges produce different training adaptations. Broadly:
 - **Strength:** ≤ 6 reps
 - **Power:** 1–6 reps
 
-As goals shift over time, lifters need a way to quickly translate a known working weight into the right weight for a new rep target. `RM_Estimator` does this translation using the ACSM percentage-of-1RM table.
+As goals shift over time, lifters need a way to quickly translate a known working weight into the right weight for a new rep target. `RM_Estimator` does this translation using a validated percentage-of-1RM table.
 
 ## Constructor Arguments
 
@@ -54,4 +54,4 @@ Percentages of 1RM from this table are accurate to within **±0.5% to 2%**, depe
 
 ## Reference
 
-For the full ACSM rep-percentage table see the [Rep Max skill reference](/Fitness-Tools/skills/rep-max-percentage-table/).
+For the full rep-percentage table see the [Rep Max skill reference](/Fitness-Tools/skills/rep-max-percentage-table/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fitness-tools"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python package for health and fitness calculations using validated, research-backed equations"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fitness-tools"
 version = "1.0.0"
-description = "Python package for health and fitness calculations using ACSM-sourced equations"
+description = "Python package for health and fitness calculations using validated, research-backed equations"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
 authors = [
-    { name = "Maverick Coders", email = "maverickcoders@pm.me" },
+    { name = "jeffallan" },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -31,6 +31,7 @@ Homepage = "https://github.com/Jeffallan/Fitness-Tools"
 Repository = "https://github.com/Jeffallan/Fitness-Tools"
 Issues = "https://github.com/Jeffallan/Fitness-Tools/issues"
 Documentation = "https://jeffallan.github.io/Fitness-Tools"
+Author = "https://jeffallan.github.io"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov", "mypy", "ruff"]

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
     starlight({
       title: 'Fitness Tools',
       description:
-        'Python package for health and fitness calculations using ACSM-sourced equations — body composition, rep max estimation, and macronutrient planning.',
+        'Python package for health and fitness calculations using validated, research-backed equations — body composition, rep max estimation, and macronutrient planning.',
       customCss: ['./src/styles/custom.css'],
       head: [
         {

--- a/site/scripts/sync-content.mjs
+++ b/site/scripts/sync-content.mjs
@@ -452,7 +452,7 @@ function generateIndexMirror() {
 
   const markdown = `# Fitness Tools
 
-> ${versionData.skillCount} specialized fitness skills — ACSM-sourced body composition, rep max estimation, and macronutrient planning.
+> ${versionData.skillCount} specialized fitness skills — validated, research-backed body composition, rep max estimation, and macronutrient planning.
 
 ## Quick Install
 
@@ -497,7 +497,7 @@ function generateLlmsTxt() {
   const lines = [];
   lines.push('# Fitness Tools');
   lines.push(
-    `> ${versionData.skillCount} specialized fitness skills — ACSM-sourced equations for body composition, rep max estimation, and macronutrient planning.`,
+    `> ${versionData.skillCount} specialized fitness skills — validated, research-backed equations for body composition, rep max estimation, and macronutrient planning.`,
   );
   lines.push('');
 

--- a/site/scripts/sync-content.mjs
+++ b/site/scripts/sync-content.mjs
@@ -462,14 +462,14 @@ Python library:
 pip install fitness-tools
 \`\`\`
 
-Agent skills (Claude Code):
+Agent Skills (Claude Code):
 
 \`\`\`
 /plugin marketplace add Jeffallan/Fitness-Tools
 /plugin install fitness-tools@fitness-tools
 \`\`\`
 
-Agent skills ([skills.sh](https://skills.sh)):
+Agent Skills ([skills.sh](https://skills.sh)):
 
 \`\`\`bash
 npx skills add Jeffallan/Fitness-Tools

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Fitness Tools
-description: Python package for health and fitness calculations using ACSM-sourced equations.
+description: Python package for health and fitness calculations using validated, research-backed equations.
 template: splash
 hero:
-  tagline: Body composition, rep max estimation, and macronutrient planning — powered by ACSM-sourced equations.
+  tagline: Body composition, rep max estimation, and macronutrient planning — powered by validated, research-backed equations.
   actions:
     - text: Get Started
       link: /Fitness-Tools/readme/
@@ -20,8 +20,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   <Card title="3 Skills" icon="puzzle">
     Claude Code skills for body composition assessment, rep max estimation, and macronutrient meal planning.
   </Card>
-  <Card title="ACSM-Sourced" icon="open-book">
-    All equations sourced from the American College of Sports Medicine guidelines.
+  <Card title="Evidence-Based" icon="open-book">
+    All equations are validated and grounded in published exercise science research.
   </Card>
   <Card title="Zero Dependencies" icon="rocket">
     100% pure Python. No third-party packages required.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
   <Card title="3 Skills" icon="puzzle">
-    Claude Code skills for body composition assessment, rep max estimation, and macronutrient meal planning.
+    Agent skills for body composition assessment, rep max estimation, and macronutrient meal planning.
   </Card>
   <Card title="Evidence-Based" icon="open-book">
     All equations are validated and grounded in published exercise science research.
@@ -33,14 +33,23 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Quick Install
 
+**Python library:**
+
 ```bash
 pip install fitness-tools
 ```
 
-### Claude Skills
+**Agent skills — Claude Code** (run inside a Claude Code session):
+
+```
+/plugin marketplace add Jeffallan/Fitness-Tools
+/plugin install fitness-tools@fitness-tools
+```
+
+**Agent skills — [skills.sh](https://skills.sh)** (from any terminal):
 
 ```bash
-claude install Jeffallan/Fitness-Tools
+npx skills add Jeffallan/Fitness-Tools
 ```
 
 See the [README](/Fitness-Tools/readme/) for full usage and API details.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
   <Card title="3 Skills" icon="puzzle">
-    Agent skills for body composition assessment, rep max estimation, and macronutrient meal planning.
+    Agent Skills for body composition assessment, rep max estimation, and macronutrient meal planning.
   </Card>
   <Card title="Evidence-Based" icon="open-book">
     All equations are validated and grounded in published exercise science research.
@@ -39,14 +39,14 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 pip install fitness-tools
 ```
 
-**Agent skills — Claude Code** (run inside a Claude Code session):
+**Agent Skills — Claude Code** (run inside a Claude Code session):
 
 ```
 /plugin marketplace add Jeffallan/Fitness-Tools
 /plugin install fitness-tools@fitness-tools
 ```
 
-**Agent skills — [skills.sh](https://skills.sh)** (from any terminal):
+**Agent Skills — [skills.sh](https://skills.sh)** (from any terminal):
 
 ```bash
 npx skills add Jeffallan/Fitness-Tools

--- a/skills/body-composition/SKILL.md
+++ b/skills/body-composition/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 ## Role Definition
 
-You are a fitness practitioner assistant specializing in body composition assessment. You guide users through skinfold-based body fat estimation using validated, ACSM-sourced equations. Always cite the specific equation used, present results with appropriate precision, note limitations, and recommend consulting a certified fitness professional for personalized guidance. **Never provide medical advice** -- frame all output as educational/informational.
+You are a fitness practitioner assistant specializing in body composition assessment. You guide users through skinfold-based body fat estimation using validated, research-backed equations. Always cite the specific equation used, present results with appropriate precision, note limitations, and recommend consulting a certified fitness professional for personalized guidance. **Never provide medical advice** -- frame all output as educational/informational.
 
 ## When to Use This Skill
 

--- a/skills/rep-max/SKILL.md
+++ b/skills/rep-max/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rep-max
-description: Use when estimating one-rep max (1RM), converting between weight and rep ranges, or calculating training loads from the ACSM percentage-of-max table.
+description: Use when estimating one-rep max (1RM), converting between weight and rep ranges, or calculating training loads from a validated percentage-of-max table.
 license: Apache-2.0
 metadata:
   author: https://github.com/Jeffallan
@@ -15,7 +15,7 @@ metadata:
 
 ## Role Definition
 
-You are a fitness practitioner assistant specializing in rep max estimation. You help users estimate their one-rep maximum and convert between weight/rep combinations using the ACSM percentage-of-1RM table. Always cite the method, note accuracy limitations, and recommend consulting a certified fitness professional. **Never provide medical advice** -- frame all output as educational/informational.
+You are a fitness practitioner assistant specializing in rep max estimation. You help users estimate their one-rep maximum and convert between weight/rep combinations using a validated percentage-of-1RM table. Always cite the method, note accuracy limitations, and recommend consulting a certified fitness professional. **Never provide medical advice** -- frame all output as educational/informational.
 
 ## When to Use This Skill
 
@@ -57,7 +57,7 @@ pip install fitness-tools
 
 | Topic | Reference |
 |-------|-----------|
-| ACSM rep-to-percentage table and estimation formula | `references/percentage-table.md` |
+| Rep-to-percentage table and estimation formula | `references/percentage-table.md` |
 
 ## Constraints
 
@@ -65,7 +65,7 @@ pip install fitness-tools
 - Round results to the nearest plate-friendly increment (2.5 or 5.0 lbs)
 - Note that accuracy decreases when extrapolating from high rep ranges (>5)
 - Present the estimated 1RM alongside the requested conversion
-- Mention the ACSM percentage table as the source method
+- Mention the validated percentage table as the source method
 
 **MUST NOT DO:**
 - Accept rep values outside 1-20 range
@@ -82,7 +82,7 @@ pip install fitness-tools
 **Estimated 1RM:** [value] lbs
 **Estimated weight for [desired_reps] reps:** [value] lbs
 
-**Method:** ACSM percentage-of-1RM table
+**Method:** Validated percentage-of-1RM table
 **Rounding:** Nearest [base] lbs
 
 **Notes:**

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "skillCount": 3,
   "referenceFileCount": 3
 }


### PR DESCRIPTION
## Summary

Bug-fix + metadata patch release. All v1.0.0 core functionality unchanged; this cleans up docs, fixes a broken quick-start example, corrects wrong enum documentation, updates author attribution, and scrubs marketing copy.

## Release checklist

- [x] Bumped version to `1.0.1` in `pyproject.toml`, `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `version.json`
- [x] CHANGELOG entry added with fixed / changed / infrastructure sections
- [x] `python -m build` locally produces clean `fitness_tools-1.0.1-*.whl` and `.tar.gz` (only `fitness_tools/` bundled)
- [ ] CI passes on this PR (first PR to run under the new trigger config after v1.0.0 bootstrap)
- [ ] Merge → tag `v1.0.1` → release workflow publishes to PyPI + deploys docs + creates GitHub Release

## What's in this release

### Fixed
- **README `DurninWomersley` example** threw `TypeError` (used `skinfolds=` keyword against `*args`). Now uses positional form matching the library doc style.
- **`ActivityLevel` accepted-values table** in `docs-library/meal-planning.md` listed `"light"` and `"extra"`, which don't exist on the enum. Removed.

### Changed
- **Author metadata** → `jeffallan` + https://jeffallan.github.io (dropped stale Maverick Coders attribution from v0.1.x).
- **ACSM marketing scrub** — README intro, PyPI description, marketplace metadata, docs-site landing page, sync-script blurbs, and agent skill role definitions no longer lead on "ACSM-sourced." Reframed as "validated, research-backed equations." Scholarly attribution in deep reference docs kept.
- **README header** — capsule-render banner (sky blue → amber), stats line, shields.io badge row.
- **Docs site landing page** — real install commands (`/plugin marketplace add` + `npx skills add`) replace the stub `claude install` command.
- Terminology unified on **"Agent Skills"** (capitalized).

### Infrastructure
- **Release workflow** — `configure-pages@v5` passes `enablement: true` so Pages auto-initializes on first run.
- **CI** triggers on develop PRs and declares `workflow_call` so release.yml can reuse it.
- **Build config** — explicit `[tool.setuptools.packages.find]` prevents flat-layout auto-discovery confusion (would have failed PyPI publish without this).

## Commits

- `6dd2347` release: v1.0.1
- `0e6126d` docs: fix broken example, wrong enum values, terminology drift
- `1c7095e` docs(site): fix landing page install instructions
- `a257bc9` docs: README header + remove forward-facing ACSM references
- `41a479c` release: auto-enable Pages on first run
- `5642f43` chore: update PyPI author metadata to jeffallan

🤖 Generated with [Claude Code](https://claude.com/claude-code)