### PR TITLE
fix(readme): banner description truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20%26%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools banner — Python Package and Agent Skills" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20and%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools banner — Python Package and Agent Skills" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Cosmetic one-line fix. The README banner's capsule-render URL had `%26` (URL-encoded `&`) in the `desc` parameter for the tagline "Python Package + Agent Skills for Health & Performance". Capsule-render's query parser decoded the `%26` during parameter splitting, truncating the rendered tagline at "Health" and producing a bogus `Performance=` empty parameter.

Swapped `&` for literal "and" to avoid the escape chain entirely.

No version bump — this is a README-only fix, no PyPI artifact changes. Landing on master so fresh GitHub visitors see the correct banner immediately. No tag, no release workflow triggered.

## Commits

- `160ac27` fix(readme): banner desc parameter broken by literal ampersand

🤖 Generated with [Claude Code](https://claude.com/claude-code)