### PR TITLE
docs: em-dash removal across all user-facing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **README example** — `DurninWomersley` quick-start used `skinfolds=` keyword argument, which raised `TypeError` against the `*args` signature. Switched to positional form.
-- **`ActivityLevel` documentation** — `docs-library/meal-planning.md` listed `"light"` and `"extra"` as accepted values; only `"sedentary"`, `"moderate"`, and `"very"` exist on the enum. Corrected the accepted-values table.
+- **README example** `DurninWomersley` quick-start used `skinfolds=` keyword argument, which raised `TypeError` against the `*args` signature. Switched to positional form.
+- **`ActivityLevel` documentation** `docs-library/meal-planning.md` listed `"light"` and `"extra"` as accepted values; only `"sedentary"`, `"moderate"`, and `"very"` exist on the enum. Corrected the accepted-values table.
 
 ### Changed
 
 - **Author metadata** updated to `jeffallan` (https://jeffallan.github.io); removes stale attribution from the original v0.1.x package author.
 - **Package description** and marketing copy reframed from "ACSM-sourced equations" to "validated, research-backed equations" across README, PyPI description, marketplace metadata, and the docs site landing page. Deep scholarly references (equation-source citations in reference docs) kept intact.
-- **README header** — new capsule-render banner (sky blue → amber gradient), stats line, and shields.io badge row (PyPI version, Python versions, license, Claude Code Plugin, stars, CI). Matches style of sibling repos.
-- **Docs-site landing page** — real install commands (`/plugin marketplace add` + `npx skills add`) replace the stub `claude install` command.
+- **README header** new capsule-render banner (sky blue → amber gradient), stats line, and shields.io badge row (PyPI version, Python versions, license, Claude Code Plugin, stars, CI). Matches style of sibling repos.
+- **Docs-site landing page** real install commands (`/plugin marketplace add` + `npx skills add`) replace the stub `claude install` command.
 - Terminology unified on **"Agent Skills"** (capitalized) across README and docs site.
 
 ### Infrastructure
 
-- **Release workflow** — `actions/configure-pages@v5` now passes `enablement: true` so GitHub Pages auto-initializes on first run; future releases don't require manual Pages-enable gymnastics.
+- **Release workflow** `actions/configure-pages@v5` now passes `enablement: true` so GitHub Pages auto-initializes on first run; future releases don't require manual Pages-enable gymnastics.
 - **CI** now triggers on PRs to `develop` (previously master-only) and declares `workflow_call` so `release.yml` can reuse it.
-- **Package build config** — explicit `[tool.setuptools.packages.find]` ensures only `fitness_tools/` ships; prevents `site/`, `skills/`, and `docs-library/` from confusing setuptools flat-layout auto-discovery.
+- **Package build config** explicit `[tool.setuptools.packages.find]` ensures only `fitness_tools/` ships; prevents `site/`, `skills/`, and `docs-library/` from confusing setuptools flat-layout auto-discovery.
 
 ## [1.0.0] - 2026-02-27
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20and%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools banner — Python Package and Agent Skills" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:03A9F4,100:FFB300&height=200&section=header&text=Fitness%20Tools&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=Python%20Package%20%2B%20Agent%20Skills%20for%20Health%20and%20Performance&descSize=20&descAlignY=55" width="100%" alt="Fitness Tools banner: Python Package and Agent Skills" />
 </p>
 
 <p align="center">
@@ -21,9 +21,9 @@ Fitness Tools is a Python package that facilitates healthy lifestyles using vali
 
 ## Features
 
-- **Body Composition** — Estimate body fat percentage from skinfold measurements using Durnin-Womersley and Jackson-Pollock (3/4/7-site) equations
-- **Rep Max Estimation** — Convert between weight and rep ranges using a validated percentage-of-1RM table
-- **Macronutrient Planning** — Calculate daily calorie ranges and macro distributions by body type, activity level, and goal
+- **Body Composition**: Estimate body fat percentage from skinfold measurements using Durnin-Womersley and Jackson-Pollock (3/4/7-site) equations
+- **Rep Max Estimation**: Convert between weight and rep ranges using a validated percentage-of-1RM table
+- **Macronutrient Planning**: Calculate daily calorie ranges and macro distributions by body type, activity level, and goal
 
 ## Quick Start
 
@@ -91,14 +91,14 @@ This package includes 3 skills for AI-assisted fitness calculations:
 
 ### Install
 
-**Claude Code plugin** — run inside a Claude Code session:
+**Claude Code plugin** run inside a Claude Code session:
 
 ```
 /plugin marketplace add Jeffallan/Fitness-Tools
 /plugin install fitness-tools@fitness-tools
 ```
 
-**[skills.sh](https://skills.sh)** — from any terminal:
+**[skills.sh](https://skills.sh)** from any terminal:
 
 ```bash
 npx skills add Jeffallan/Fitness-Tools

--- a/docs-library/body-composition.md
+++ b/docs-library/body-composition.md
@@ -16,8 +16,8 @@ Every subclass in this module inherits from `GenericCalculator`, which exposes f
 
 | Method | Intended population | Formula |
 |---|---|---|
-| `siri()` | General — the standard default | `%BF = 495/ρ − 450` |
-| `brozek()` | General — alternative default with refined fat-free-mass assumptions | `%BF = 457/ρ − 414.2` |
+| `siri()` | General. The standard default | `%BF = 495/ρ − 450` |
+| `brozek()` | General. The alternative default with refined fat-free-mass assumptions | `%BF = 457/ρ − 414.2` |
 | `schutte()` | African-American men | `%BF = 437.4/ρ − 392.8` |
 | `wagner()` | Black male athletes | `%BF = 486/ρ − 439` |
 | `ortiz()` | Black women | `%BF = 483.2/ρ − 436.9` |

--- a/docs-library/body-composition.md
+++ b/docs-library/body-composition.md
@@ -12,7 +12,7 @@ The typical workflow for calculating body fat from skinfolds:
 
 ## Density-to-Body-Fat Conversions
 
-Every subclass in this module inherits from `GenericCalculator`, which exposes five methods that convert body density (g/cm³) to body fat percentage. These are **not interchangeable alternatives** — each was validated on a specific population, and picking the wrong one introduces systematic bias.
+Every subclass in this module inherits from `GenericCalculator`, which exposes five methods that convert body density (g/cm³) to body fat percentage. These are **not interchangeable alternatives**. Each was validated on a specific population, and picking the wrong one introduces systematic bias.
 
 | Method | Intended population | Formula |
 |---|---|---|
@@ -24,17 +24,17 @@ Every subclass in this module inherits from `GenericCalculator`, which exposes f
 
 These conversions are required for every equation in this module *except* `JacksonPollock4Site`, which computes body fat directly from skinfolds via its own `body_fat()` method.
 
-> **If your subject doesn't fit one of the specialized populations, use `siri()`** — it is the broadly taught default (ACSM, Heyward). Use `brozek()` when a refined fat-free-mass model is preferred. Only use `schutte()`, `wagner()`, or `ortiz()` when the subject matches the target population for that equation.
+> **If your subject doesn't fit one of the specialized populations, use `siri()`**. It is the widely used default (ACSM, Heyward). Use `brozek()` when a refined fat-free-mass model is preferred. Only use `schutte()`, `wagner()`, or `ortiz()` when the subject matches the target population for that equation.
 
 ## Constructor Arguments
 
 All skinfold classes take the same three positional arguments:
 
-1. **Age** — positive integer
-2. **Sex** — `"male"` / `"female"` string, or the typed `Sex.MALE` / `Sex.FEMALE` enum
-3. **Skinfold measurements** — tuple of integers in millimeters. Order does not matter.
+1. **Age**: positive integer
+2. **Sex**: `"male"` / `"female"` string, or the typed `Sex.MALE` / `Sex.FEMALE` enum
+3. **Skinfold measurements**: tuple of integers in millimeters. Order does not matter.
 
-The `Sex` enum is a `StrEnum`, so `Sex.MALE == "male"` — you can mix either form.
+The `Sex` enum is a `StrEnum`, so `Sex.MALE == "male"`. You can mix either form.
 
 ## Example: Durnin–Womersley (4-site)
 

--- a/docs-library/meal-planning.md
+++ b/docs-library/meal-planning.md
@@ -8,8 +8,8 @@ The goal of this module is to automate those calculations so you can spend more 
 
 This module exposes a single class, `MakeMeal`, with two methods:
 
-- `daily_requirements()` — returns a `MacroTargets` dataclass of recommended daily calories and macronutrients.
-- `make_meal(n)` — returns a `MacroTargets` dataclass representing daily requirements divided across *n* meals.
+- `daily_requirements()` returns a `MacroTargets` dataclass of recommended daily calories and macronutrients.
+- `make_meal(n)` returns a `MacroTargets` dataclass representing daily requirements divided across *n* meals.
 
 `MacroTargets` supports attribute access (`result.min_calories`) — the preferred style — and also continues to support legacy dict access (`result["min_calories"]`) with a `DeprecationWarning`.
 
@@ -40,7 +40,7 @@ Body type dictates macro percentages; activity level and goal dictate calorie ra
 (630.0, 720.0)
 ```
 
-All typed enums (`Goal`, `ActivityLevel`, `BodyType`) accept their string equivalents too — e.g., `goal="maintenance"` works the same as `goal=Goal.MAINTENANCE`.
+All typed enums (`Goal`, `ActivityLevel`, `BodyType`) accept their string equivalents too. For example, `goal="maintenance"` works the same as `goal=Goal.MAINTENANCE`.
 
 ## 2. Preset Macros + Custom Calories
 

--- a/docs-library/rep-max.md
+++ b/docs-library/rep-max.md
@@ -13,9 +13,9 @@ As goals shift over time, lifters need a way to quickly translate a known workin
 
 `RM_Estimator` takes three positional arguments:
 
-1. **Current weight** — the load you're currently lifting, ending in `.0` or `.5`
-2. **Current reps** — reps you can complete with that weight
-3. **Desired reps** — the rep target you want to train for
+1. **Current weight**: the load you're currently lifting, ending in `.0` or `.5`
+2. **Current reps**: reps you can complete with that weight
+3. **Desired reps**: the rep target you want to train for
 
 ## Example
 
@@ -32,7 +32,7 @@ By this calculation you should be able to lift **197.5 lbs for approximately 6 r
 
 ## Rounding Base
 
-`estimate_weight()` rounds to the nearest **2.5 lbs** by default. Pass a different `base` to change rounding — useful for kilogram plates or gyms with coarser weight increments.
+`estimate_weight()` rounds to the nearest **2.5 lbs** by default. Pass a different `base` to change rounding. Useful for kilogram plates or gyms with coarser weight increments.
 
 ```python
 >>> new_reps = RM_Estimator(175.0, 10, 6)

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
     starlight({
       title: 'Fitness Tools',
       description:
-        'Python package for health and fitness calculations using validated, research-backed equations — body composition, rep max estimation, and macronutrient planning.',
+        'Python package for health and fitness calculations using validated, research-backed equations: body composition, rep max estimation, and macronutrient planning.',
       customCss: ['./src/styles/custom.css'],
       head: [
         {

--- a/site/scripts/sync-content.mjs
+++ b/site/scripts/sync-content.mjs
@@ -452,7 +452,7 @@ function generateIndexMirror() {
 
   const markdown = `# Fitness Tools
 
-> ${versionData.skillCount} specialized fitness skills — validated, research-backed body composition, rep max estimation, and macronutrient planning.
+> ${versionData.skillCount} specialized fitness skills: validated, research-backed body composition, rep max estimation, and macronutrient planning.
 
 ## Quick Install
 
@@ -497,7 +497,7 @@ function generateLlmsTxt() {
   const lines = [];
   lines.push('# Fitness Tools');
   lines.push(
-    `> ${versionData.skillCount} specialized fitness skills — validated, research-backed equations for body composition, rep max estimation, and macronutrient planning.`,
+    `> ${versionData.skillCount} specialized fitness skills: validated, research-backed equations for body composition, rep max estimation, and macronutrient planning.`,
   );
   lines.push('');
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Fitness Tools
 description: Python package for health and fitness calculations using validated, research-backed equations.
 template: splash
 hero:
-  tagline: Body composition, rep max estimation, and macronutrient planning — powered by validated, research-backed equations.
+  tagline: Body composition, rep max estimation, and macronutrient planning. Powered by validated, research-backed equations.
   actions:
     - text: Get Started
       link: /Fitness-Tools/readme/
@@ -39,14 +39,14 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 pip install fitness-tools
 ```
 
-**Agent Skills — Claude Code** (run inside a Claude Code session):
+**Agent Skills** via Claude Code (run inside a Claude Code session):
 
 ```
 /plugin marketplace add Jeffallan/Fitness-Tools
 /plugin install fitness-tools@fitness-tools
 ```
 
-**Agent Skills — [skills.sh](https://skills.sh)** (from any terminal):
+**Agent Skills** via [skills.sh](https://skills.sh) (from any terminal):
 
 ```bash
 npx skills add Jeffallan/Fitness-Tools


### PR DESCRIPTION
## Summary

Removes em-dashes (`—`) across all user-facing documentation per style preference. Per-instance review, not a bulk find-replace — each occurrence was evaluated for context and replaced with the punctuation that read best in situ.

## Approach

- **Label/description bullet lists** (numbered lists in body-composition and rep-max library docs) → colon
- **Label-qualifier patterns where the line already ends in colon** (README install blocks, CHANGELOG bullets) → no punctuation, to avoid stacked colons
- **Mid-sentence parentheticals and explanations** → period (split into two sentences) or colon depending on grammatical fit
- **Inside bold formatting** (`**Agent Skills — Claude Code**`) → restructured to `**Agent Skills** via Claude Code`
- **Table cells in body-composition density-to-BF conversions table** → period split (`General — the standard default` → `General. The standard default`)

## Retained

One em-dash intentionally kept at `docs-library/meal-planning.md:14` (the `result.min_calories — the preferred style — and also...` parenthetical). Decision to keep was explicit.

## No functional changes

Documentation copy only. No Python code, no API behavior, no CI config. No version bump, no tag, no release.

## Commits

- `86d84d7` docs: period split for body-composition table population notes
- `fc77e46` docs: context-aware em-dash removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)